### PR TITLE
Solving permanent lazy highlighting... without knowing how :-(

### DIFF
--- a/ace-isearch.el
+++ b/ace-isearch.el
@@ -173,7 +173,8 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
          (goto-char isearch-opoint)
          (if (or (< (point) (window-start)) (> (point) (window-end)))
              (message "Notice: Character '%s' could not be found in the \"selected visible window\"." isearch-string))
-         (funcall ace-isearch-function (string-to-char isearch-string)))
+         (funcall ace-isearch-function (string-to-char isearch-string))
+         (isearch-exit))
 
         ((and (> (length isearch-string) 1)
               (< (length isearch-string) ace-isearch-input-length)
@@ -189,7 +190,8 @@ of `isearch-string' is longer than or equal to `ace-isearch-input-length'."
                 ace-isearch-use-function-from-isearch)
               (sit-for ace-isearch-func-delay))
          (isearch-exit)
-         (funcall ace-isearch-function-from-isearch))))
+         (funcall ace-isearch-function-from-isearch)
+         (isearch-exit))))
 
 (defun ace-isearch-pop-mark ()
   "Jump back to the last location of `ace-jump-mode' invoked or `avy-push-mark'."


### PR DESCRIPTION
I really don't know why another (isearch-exit) is needed, but it seems to work.

When searching long words with "helm-swoop" there is a small delay between the end of the search and the removal of the highlighting. Don't know why neither :-(

I think that without knowing why this works, It shouldn't be merged, but perhaps you have an idea of why this solves the problem.